### PR TITLE
Visualise button presses from URL on mount

### DIFF
--- a/src/components/keypad/index.svelte
+++ b/src/components/keypad/index.svelte
@@ -33,6 +33,9 @@
       !isNaN(parseInt(code))
     ) {
       const fingerprints = code.split('').map((number) => parseInt(number));
+      for (const fingerprint of fingerprints) {
+        toggleButton(fingerprint.toString())
+      }
       pressedNumbers.update(
         (numbers) => [...numbers, ...fingerprints] as never[],
       );


### PR DESCRIPTION
## Before

If the page is refreshed after entering a code, or if a URL is visited directly (e.g. [pd3-vault-cracker/?code=1234](https://savagecore.github.io/pd3-vault-cracker/?code=1234)) then the pressed buttons are not highlighted.

<img width="344" alt="before" src="https://github.com/SavageCore/pd3-vault-cracker/assets/44623945/0335e8e1-2771-4da9-9924-293facb87d80">

## After

<img width="343" alt="after" src="https://github.com/SavageCore/pd3-vault-cracker/assets/44623945/2e38da8d-097c-4889-ab34-7364c4648247">